### PR TITLE
lodash is a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "gruntfile-api": "0.0.9",
     "glob": "^3.2.9",
     "prettyjson": "^1.0.0",
+    "lodash": "^2.4.1",
     "editorconfig": "^0.11.4"
   },
   "devDependencies": {
     "mocha": "*",
-    "lodash": "^2.4.1",
     "loglevel": "^0.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Installing via yeoman into a fresh directory will cause an error because lodash is listed as a dev dependency . It is required in the index.js file so it should be a runtime dependency.
